### PR TITLE
[BUGFIX] Fix regex expression for Ical import

### DIFF
--- a/Resources/Private/Contrib/Ical.php
+++ b/Resources/Private/Contrib/Ical.php
@@ -196,7 +196,7 @@ class Ical
      */
     public function keyValueFromString($text)
     {
-        preg_match('/([A-Za-z-\/;=^:]+)[:]([\w\W]*)/', $text, $matches);
+        preg_match('/([A-Za-z-\/;=^:]+?):([\w\W]*)/', $text, $matches);
         if (count($matches) == 0) {
             return false;
         }


### PR DESCRIPTION
This change fixes the regex for Ical values so that titles which start with "Foo: Bar" don't get matched by the first group as array key anymore.

Example:

Value in ICal: `SUMMARY:Foo: Bar Lorem Ipsum`

**Before:**
**SUMMARY:Foo**: Bar Lorem Ipsum

First Group is: SUMMARY:Foo
Second Group is: Bar Lorem Ipsum

**After:**
**SUMMARY**:Foo: Bar Lorem Ipsum

First Group is: SUMMARY
Second Group is: Foo: Bar Lorem Ipsum

**_News with such titles have missing titles in the record because the array key was invalid._**