### PR TITLE
[BUGFIX] Correct TYPO3 dependencies in ext_emconf

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -13,7 +13,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' =>
         [
             'depends' => [
-                'typo3' => '9.5.99-10.4.99',
+                'typo3' => '9.5.0-10.4.99',
                 'news' => '8.0.0-8.99.99'
             ],
             'conflicts' => [],


### PR DESCRIPTION
Hi, i currently can't install the extension under TYPO3 9 in non-composwer mode.

```
"news_importicsxml" requires TYPO3 versions 9.5.99 - 10.4.99. It is not compatible with TYPO3 version "9.5.21"
```

I think there is a mistake in the typo3 dependency.
https://github.com/georgringer/news_importicsxml/blob/ae32bf456412bad52278097bd2e8e377de03631c/ext_emconf.php#L16

This PR fixes the TYPO3 dependencies.