### PR TITLE
[BUGFIX] Replace deprecated curly brace syntax with square brackets

### DIFF
--- a/Resources/Private/Contrib/picoFeed/lib/PicoFeed/Client/Url.php
+++ b/Resources/Private/Contrib/picoFeed/lib/PicoFeed/Client/Url.php
@@ -141,7 +141,7 @@ class Url
     public function isRelativePath()
     {
         $path = $this->getPath();
-        return empty($path) || $path{0} !== '/';
+        return empty($path) || $path[0] !== '/';
     }
 
     /**


### PR DESCRIPTION
Without this change the extension doesn't work for me at all in TYPO3 10.4 with PHP 7.4.
It simply logs and prints a deprecation error and kills itself.
While this fix will get the extension to work for me (it didn't work before), the picoFeed package that is being used internally (and contains the changed file) should be updated at some point in the future nonetheless.

I just wanted to get this working. And it does now.

Resolves: #19