### PR TITLE
[BUGFIX] dependiencies error georgringer/news-importicsxml dev-master…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "georgringer/news": "^8 || 9",
-    "typo3/cms-scheduler": "10.4 || ^11.5",
+    "typo3/cms-scheduler": "^10.4 || ^11.5",
     "typo3/cms-core": "^10.4 || ^11.5"
   },
   "autoload": {


### PR DESCRIPTION
… requires typo3/cms-scheduler 10.4 || ^11.5 -> found typo3/cms-scheduler[v10.4.0, v11.5.0, v11.5.1, v11.5.2] but the package is fixed to v10.4.21 (lock file version) by a partial