### PR TITLE
Update dependeny constraints in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "GPL-2.0-or-later"
   ],
   "require": {
-    "georgringer/news": "^8 || 9",
-    "typo3/cms-scheduler": "10.4 || ^11.5",
+    "georgringer/news": "^8 || ^9",
+    "typo3/cms-scheduler": "^10.4 || ^11.5",
     "typo3/cms-core": "^10.4 || ^11.5"
   },
   "autoload": {


### PR DESCRIPTION
Fix dependeny constraints for georgringer/news (allow all versions in v9 branch) and typo3/cms-scheduler (allow all versions in v10.4 branch)