### PR TITLE
Ran into some problems after updating to v12.4.11 - fix version constraints and return type of command execute method

### DIFF
--- a/Classes/Command/ImportCommand.php
+++ b/Classes/Command/ImportCommand.php
@@ -45,7 +45,7 @@ class ImportCommand extends Command
             ->setDescription('Import of ICS and XML (RSS) into EXT:news');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $io->title($this->getDescription());

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "GPL-2.0-or-later"
   ],
   "require": {
-    "georgringer/news": "^11.1.3",
+    "georgringer/news": "^11.4",
     "typo3/cms-scheduler": "^11.5 || ^12.4",
     "typo3/cms-core": "^11.5 || ^12.4"
   },


### PR DESCRIPTION
The extension requires an older version of news, and so I ran into 

...must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int

The pull request fixes the constraint and the return type of the execute method in the command.