### PR TITLE
[BUGFIX] Parameter mapping delimiter: | instead of LF

### DIFF
--- a/Classes/Domain/Model/Dto/TaskConfiguration.php
+++ b/Classes/Domain/Model/Dto/TaskConfiguration.php
@@ -181,7 +181,7 @@ class TaskConfiguration
     public function getMappingConfigured()
     {
         $out = [];
-        $lines = GeneralUtility::trimExplode(LF, $this->mapping, true);
+        $lines = GeneralUtility::trimExplode('|', $this->mapping, true);
         foreach ($lines as $line) {
             $split = GeneralUtility::trimExplode(':', $line, true, 2);
             $out[$split[1]] = $split[0];

--- a/Classes/Mapper/IcsMapper.php
+++ b/Classes/Mapper/IcsMapper.php
@@ -115,11 +115,16 @@ class IcsMapper extends AbstractMapper implements MapperInterface
                 $this->logger->info('Categories found during import but no mapping assigned in the task!');
             } else {
                 $categoryMapping = $configuration->getMappingConfigured();
-                foreach ($categoryTitles as $title) {
-                    if (!isset($categoryMapping[$title])) {
-                        $this->logger->warning(sprintf('Category mapping is missing for category "%s"', $title));
-                    } else {
-                        $categoryIds[] = $categoryMapping[$title];
+
+                foreach ($categoryTitles as $rawTitle) {
+                    $splitTitle = GeneralUtility::trimExplode(',', $rawTitle, true, 0);
+
+                    foreach ($splitTitle as $title) {
+                        if (!isset($categoryMapping[$title])) {
+                            $this->logger->warning(sprintf('Category mapping is missing for category "%s"', $title));
+                        } else {
+                            $categoryIds[] = $categoryMapping[$title];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
TYPO3s backend does not support LF as delimter. Use pipe (|) instead as propesed in issue #44 

Resolves: #44