### PR TITLE
[FEATURE] ICS import: Category mapping to support multiple categories

### DIFF
--- a/Classes/Mapper/IcsMapper.php
+++ b/Classes/Mapper/IcsMapper.php
@@ -115,11 +115,16 @@ class IcsMapper extends AbstractMapper implements MapperInterface
                 $this->logger->info('Categories found during import but no mapping assigned in the task!');
             } else {
                 $categoryMapping = $configuration->getMappingConfigured();
-                foreach ($categoryTitles as $title) {
-                    if (!isset($categoryMapping[$title])) {
-                        $this->logger->warning(sprintf('Category mapping is missing for category "%s"', $title));
-                    } else {
-                        $categoryIds[] = $categoryMapping[$title];
+
+                foreach ($categoryTitles as $rawTitle) {
+                    $splitTitle = GeneralUtility::trimExplode(',', $rawTitle, true, 0);
+
+                    foreach ($splitTitle as $title) {
+                        if (!isset($categoryMapping[$title])) {
+                            $this->logger->warning(sprintf('Category mapping is missing for category "%s"', $title));
+                        } else {
+                            $categoryIds[] = $categoryMapping[$title];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
ICS allows multiple categories to be assigned. Their order is defined in standard, so need to handle this during parsing

Resolves: #45